### PR TITLE
Reversed ordering in Makefile when processing files in utilities/ dir…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ ifeq ($(PG95),yes)
 
 all: $(EXTENSION)--$(EXTVERSION).sql
 
-$(EXTENSION)--$(EXTVERSION).sql: sql/utilities/*.plpgsql \
-				 sql/utilities/*.sql \
+$(EXTENSION)--$(EXTVERSION).sql: sql/utilities/*.sql \
+				 sql/utilities/*.plpgsql \
 				sql/types/*.sql \
 				sql/operators/*.sql \
 				sql/functions/*.sql \


### PR DESCRIPTION
Fixed bug in CREATE EXTENSION due to bad ordering of requirement paths. Since regular_grid.plpgsql is processed before grids.sql, a refrence to type 'grid' is made before the type has been actually defined. This causes an exception in CREATE EXTENSION that breaks the install process.